### PR TITLE
Fixed ReferenceError caused by accessing wrong devices variable

### DIFF
--- a/frontend/src/components/devices/buttons/generic.js
+++ b/frontend/src/components/devices/buttons/generic.js
@@ -76,7 +76,7 @@ function GenericDeviceButton({ jsonMeta, setCurrentDevice }) {
   }
 
   useEffect(() => {
-    if (typeof navigator.bluetooth === "undefined" && device === "Muse") {
+    if (typeof navigator.bluetooth === "undefined" && jsonMeta.device === "Muse") {
       setDisabled(true);
     }
     if (jsonMeta.connections !== "multiple" && deviceStreams.length > 0) {


### PR DESCRIPTION
Visiting the "Data" view (top right button) on the [current website](https://youquantified.com/) shows a blank white screen caused by a `Uncaught ReferenceError: device is not defined`.
Switching `device` for (what I assume should be) `jsonMeta.device` fixes this and shows the device selection as expected.
